### PR TITLE
Updated reactions viewset to only allow admins to change values, otherwise read-only

### DIFF
--- a/rareserverapi/views/reactions.py
+++ b/rareserverapi/views/reactions.py
@@ -1,8 +1,20 @@
 from rest_framework.viewsets import ModelViewSet
 from rareserverapi.models import Reaction
 from rareserverapi.serializers import ReactionSerializer
+from rest_framework import permissions
+from rest_framework.permissions import IsAdminUser
+
+
+# Creates a read only permission which allows 'GET', 'OPTIONS', or 'HEAD' HTTP actions (i.e. SAFE_METHODS)
+class ReadOnly(permissions.BasePermission):
+    def has_permission(self, request, view):
+        return request.method in permissions.SAFE_METHODS
 
 
 class ReactionViewSet(ModelViewSet):
     queryset = Reaction.objects.all()
     serializer_class = ReactionSerializer
+
+    # Allow admin users (user.is_staff == True) ALL permissions
+    # otherwise, regular users are read only per above permission
+    permission_classes = [IsAdminUser | ReadOnly]


### PR DESCRIPTION
* When interacting with reactions via the API, only admins are allowed to create, update, or delete a reaction.
* Non-admins are only allowed to read the specific reactions.